### PR TITLE
Add iOS availability checks

### DIFF
--- a/Sources/Matft/core/object/mfarray.swift
+++ b/Sources/Matft/core/object/mfarray.swift
@@ -116,6 +116,7 @@ open class MfArray: MfArrayProtocol{
     ///    - base: A base MLShapedArray
     ///    - share: Whether to share memories or not, by default to true
     @available(macOS 12.0, *)
+    @available(iOS 14.0, *)
     public init (base: inout MLMultiArray, share: Bool = true){
         precondition([MLMultiArrayDataType.float, MLMultiArrayDataType.double].contains(base.dataType), "Must be float or double in share mode")
         // note that base is not assigned here!

--- a/Sources/Matft/core/object/mftype.swift
+++ b/Sources/Matft/core/object/mftype.swift
@@ -66,6 +66,7 @@ public enum MfType: Int{
     }
     
     @available(macOS 10.13, *)
+    @available(iOS 14.0, *)
     static internal func mftype(value: MLMultiArrayDataType) -> MfType{
         switch value {
         case .double:

--- a/Sources/Matft/core/protocol/mfdataProtocol.swift
+++ b/Sources/Matft/core/protocol/mfdataProtocol.swift
@@ -13,4 +13,5 @@ public protocol MfDataBasable {}
 extension MfData: MfDataBasable{}
 
 @available(macOS 10.13, *)
+@available(iOS 14.0, *)
 extension MLMultiArray: MfDataBasable{}

--- a/Tests/MatftTests/CreationTest.swift
+++ b/Tests/MatftTests/CreationTest.swift
@@ -6,6 +6,7 @@ import CoreML
 final class CreationTests: XCTestCase {
     
     @available(macOS 12.0, *)
+    @available(iOS 14.0, *)
     func testFromMLMultiArray() {
         do {
             let scalars = Array<Float>(stride(from: 0, to: 28, by: 2))
@@ -33,6 +34,7 @@ final class CreationTests: XCTestCase {
     }
     
     @available(macOS 12.0, *)
+    @available(iOS 14.0, *)
     func testFromMLMultiArrayShare() {
         do {
             let scalars = Array<Float>(stride(from: 0, to: 28, by: 2))


### PR DESCRIPTION
This commit adds `@available` equivalents where they are present for macOS for iOS compatibility.

This has been tested and resolves the issue I was having compiling with Matft on an iOS target. The minimum iOS target used is `14.0`, where attributes such as `.float` were added.